### PR TITLE
Upgrade setup.py

### DIFF
--- a/beakerx_tabledisplay/MANIFEST.in
+++ b/beakerx_tabledisplay/MANIFEST.in
@@ -1,9 +1,23 @@
+include setup.py
 graft beakerx_tabledisplay/static
 graft beakerx_tabledisplay/labextension
 
-graft beakerx_tabledisplay/js
+# Javascript files
+graft js
+prune **/node_modules
+prune js/lib
+prune js/css
+prune js/dist
 
 include LICENSE
 include NOTICE
 include pyproject.toml
 include beakerx_tabledisplay.json
+
+# Patterns to exclude from any directory
+global-exclude *~
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude .git
+global-exclude .ipynb_checkpoints
+

--- a/beakerx_tabledisplay/js/package.json
+++ b/beakerx_tabledisplay/js/package.json
@@ -2,13 +2,17 @@
   "name": "@beakerx/beakerx-tabledisplay",
   "version": "2.3.11",
   "description": "BeakerX: Beaker TableDisplay Extension for Jupyter Notebook and Lab",
+  "homepage": "http://beakerx.com/",
   "keywords": [
     "jupyter",
     "jupyterlab",
     "jupyterlab notebook",
     "jupyterlab-extension"
   ],
-  "author": "Two Sigma Open Source, LLC",
+  "author": {
+    "name": "Two Sigma Open Source, LLC",
+    "email": "beakerx-feedback@twosigma.com"
+  },
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "repository": {

--- a/beakerx_tabledisplay/pyproject.toml
+++ b/beakerx_tabledisplay/pyproject.toml
@@ -1,3 +1,16 @@
 [build-system]
-requires = ["jupyter_packaging~=0.7.9", "jupyterlab>=3.0.0,==3.*", "setuptools>=40.8.0", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["jupyter_packaging~=0.10,<2", "jupyterlab~=3.1"]
+build-backend = "jupyter_packaging.build_api"
+
+[tool.jupyter-packaging.options]
+ensured-targets = ["beakerx_tabledisplay/static/index.js", "beakerx_tabledisplay/labextension/package.json"]
+
+[tool.jupyter-packaging.builder]
+factory = "jupyter_packaging.npm_builder"
+
+[tool.jupyter-packaging.build-args]
+path = "js"
+build_cmd = "build:labextension"
+npm = ["yarn"]
+build_dir = "js/dist"
+source_dir = "js/src"

--- a/beakerx_tabledisplay/setup.py
+++ b/beakerx_tabledisplay/setup.py
@@ -14,105 +14,112 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
+import sys
+from pathlib import Path
 
-from os import path
+import setuptools
 
-from jupyter_packaging import (
-    create_cmdclass, install_npm, ensure_targets,
-    combine_commands, ensure_python,
-    get_version
-)
+HERE = Path(__file__).parent.resolve()
 
-from setuptools import setup, find_packages
-
+# Get the package info from package.json
+pkg_json_path = HERE / "js/package.json"
+pkg_json = json.loads(pkg_json_path.read_bytes())
 
 # The name of the project
-name = 'beakerx_tabledisplay'
-npm_name = '@beakerx/beakerx-tabledisplay'
+name = "beakerx_tabledisplay"
 
-HERE = path.dirname(path.abspath(__file__))
-
-# Ensure a valid python version
-ensure_python('>=3.7')
-
-# Get our version
-version = get_version(path.join(name, '_version.py'))
-
-nb_path = path.join(HERE, name, 'static')
-lab_path = path.join(HERE, name, 'labextension')
+lab_path = (pkg_json_path.parent / pkg_json["jupyterlab"]["outputDir"]).resolve()
+nb_path = HERE / name / "static"
 
 # Representative files that should exist after a successful build
-jstargets = [
-    path.join(nb_path, 'index.js'),
-    path.join(lab_path, 'package.json'),
+ensured_targets = [
+    str(nb_path / "index.js"),
+    str(lab_path / "package.json"),
 ]
 
-package_data_spec = {
-    name: [
-        'static/*.*js*',
-        'labextension/*'
-    ]
-}
-
+labext_name = pkg_json["name"]
 data_files_spec = [
-    ('share/jupyter/nbextensions/beakerx_tabledisplay', nb_path, '**'),
-    ("share/jupyter/labextensions/" + npm_name, lab_path, "**"),
-    ('etc/jupyter/nbconfig/notebook.d', HERE, 'beakerx_tabledisplay.json')
+    (
+        "share/jupyter/nbextensions/beakerx_tabledisplay",
+        str(nb_path.relative_to(HERE)),
+        "**",
+    ),
+    (
+        "share/jupyter/labextensions/%s" % labext_name,
+        str(lab_path.relative_to(HERE)),
+        "**",
+    ),
+    ("etc/jupyter/nbconfig/notebook.d", str(HERE), "beakerx_tabledisplay.json"),
 ]
 
-cmdclass = create_cmdclass('js', package_data_spec=package_data_spec, data_files_spec=data_files_spec)
-cmdclass['js'] = combine_commands(
-    install_npm(
-        path=path.join(HERE, 'js'),
-        npm=["yarn"],
-        build_cmd="build:labextension",
-        build_dir=path.join(HERE, 'js', 'dist'),
-        source_dir=path.join(HERE, 'js', 'src')
-    ),
-    ensure_targets(jstargets),
+version = (
+    pkg_json["version"]
+    .replace("-alpha.", "a")
+    .replace("-beta.", "b")
+    .replace("-rc.", "rc")
 )
 
 setup_args = dict(
     name=name,
-    description='BeakerX: Beaker Extensions for Jupyter Notebook',
-    long_description='BeakerX: Beaker Extensions for Jupyter Notebook',
     version=version,
-    author='Two Sigma Open Source, LLC',
-    author_email='beakerx-feedback@twosigma.com',
-    url='http://beakerx.com',
-    keywords=[
-        'ipython',
-        'jupyter',
-        'widgets'
-    ],
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Framework :: IPython',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Science/Research',
-        'Topic :: Multimedia :: Graphics',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-    ],
-    entry_points={
-        'console_scripts': [
-            'beakerx_tabledisplay = beakerx_tabledisplay:run'
-        ]
-    },
-    install_requires=[
-        'beakerx_base>=2.0.1',
-        'numpy',
-        'pandas'
-    ],
-    python_requires='>=3',
+    url=pkg_json["homepage"],
+    author=pkg_json["author"]["name"],
+    author_email=pkg_json["author"]["email"],
+    description=pkg_json["description"],
+    license=pkg_json["license"],
+    license_file="LICENSE",
+    long_description=pkg_json["description"],
+    packages=setuptools.find_packages(),
+    install_requires=["beakerx_base>=2.0.1", "numpy", "pandas"],
     zip_safe=False,
     include_package_data=True,
-    packages=find_packages(),
-    cmdclass=cmdclass
+    python_requires=">=3",
+    platforms="Linux, Mac OS X, Windows",
+    keywords=["ipython", "jupyter", "widgets"],
+    classifiers=[
+        "License :: OSI Approved :: Apache Software License",
+        "Development Status :: 5 - Production/Stable",
+        "Framework :: IPython",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        "Topic :: Multimedia :: Graphics",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Framework :: Jupyter",
+    ],
+    entry_points={
+        "console_scripts": ["beakerx_tabledisplay = beakerx_tabledisplay:run"]
+    },
 )
 
-if __name__ == '__main__':
-    setup(**setup_args)
+try:
+    from jupyter_packaging import wrap_installers, npm_builder, get_data_files
+
+    post_develop = npm_builder(
+        path=str(pkg_json_path.parent),
+        build_cmd="build:labextension",
+        source_dir=str(pkg_json_path.parent / "src"),
+        build_dir=str(pkg_json_path.parent / "dist"),
+        npm=["yarn"],
+    )
+    setup_args["cmdclass"] = wrap_installers(
+        post_develop=post_develop, ensured_targets=ensured_targets
+    )
+    setup_args["data_files"] = get_data_files(data_files_spec)
+except ImportError as e:
+    import logging
+
+    logging.basicConfig(format="%(levelname)s: %(message)s")
+    logging.warning(
+        "Build tool `jupyter-packaging` is missing. Install it with pip or conda."
+    )
+    if not ("--name" in sys.argv or "--version" in sys.argv):
+        raise e
+
+if __name__ == "__main__":
+    setuptools.setup(**setup_args)


### PR DESCRIPTION
To check this PR, I compare the list of files in the sdist and the wheel generated without this PR and with it.

The source package is exactly the same and the wheel is almost the same:

```diff
@@ -284,12 +284,12 @@
     17272  2022-02-23 08:23   beakerx_tabledisplay-2.3.11.data/data/share/jupyter/nbextensions/beakerx_tabledisplay/css/fonts/KaTeX_Typewriter-Regular.woff2
    297272  2022-02-23 08:23   beakerx_tabledisplay-2.3.11.data/data/share/jupyter/nbextensions/beakerx_tabledisplay/css/fonts/Lato-Black.woff
    309192  2022-02-23 08:23   beakerx_tabledisplay-2.3.11.data/data/share/jupyter/nbextensions/beakerx_tabledisplay/css/fonts/Lato-Regular.woff
-    11324  2022-04-28 15:07   beakerx_tabledisplay-2.3.11.dist-info/LICENSE
-      970  2022-04-28 15:07   beakerx_tabledisplay-2.3.11.dist-info/METADATA
-      192  2022-04-28 15:07   beakerx_tabledisplay-2.3.11.dist-info/NOTICE
-       92  2022-04-28 15:07   beakerx_tabledisplay-2.3.11.dist-info/WHEEL
-       66  2022-04-28 15:07   beakerx_tabledisplay-2.3.11.dist-info/entry_points.txt
-       21  2022-04-28 15:07   beakerx_tabledisplay-2.3.11.dist-info/top_level.txt
-    47459  2022-04-28 15:07   beakerx_tabledisplay-2.3.11.dist-info/RECORD
+    11324  2022-04-28 15:28   beakerx_tabledisplay-2.3.11.dist-info/LICENSE
+     1175  2022-04-28 15:28   beakerx_tabledisplay-2.3.11.dist-info/METADATA
+      192  2022-04-28 15:28   beakerx_tabledisplay-2.3.11.dist-info/NOTICE
+       92  2022-04-28 15:28   beakerx_tabledisplay-2.3.11.dist-info/WHEEL
+       66  2022-04-28 15:28   beakerx_tabledisplay-2.3.11.dist-info/entry_points.txt
+       21  2022-04-28 15:28   beakerx_tabledisplay-2.3.11.dist-info/top_level.txt
+    47460  2022-04-28 15:28   beakerx_tabledisplay-2.3.11.dist-info/RECORD
 ---------                     -------
- 31949114                     290 files
+ 31949320                     290 files
```

The difference is only on the size of the metadata and record files that are updated in this PR.