### PR TITLE
Fix install command for JupyterLab >=3

### DIFF
--- a/beakerx_tabledisplay/beakerx_tabledisplay/install.py
+++ b/beakerx_tabledisplay/beakerx_tabledisplay/install.py
@@ -25,7 +25,7 @@ except:
 
 def install(args):
     subprocess.check_call(["jupyter", "serverextension", "enable", "beakerx_tabledisplay", "--py", "--sys-prefix"])
-    if LAB_VERSION is not None and LAB_VERSION != 3:
+    if LAB_VERSION is not None and LAB_VERSION < 3:
         subprocess.call(["jupyter", "labextension", "install", "@jupyter-widgets/jupyterlab-manager", "--no-build"],
                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         if LAB_VERSION == 1:
@@ -38,7 +38,7 @@ def uninstall(args):
     subprocess.check_call(["jupyter", "nbextension", "disable", "beakerx_tabledisplay", "--py", "--sys-prefix"])
     subprocess.check_call(["jupyter", "nbextension", "uninstall", "beakerx_tabledisplay", "--py", "--sys-prefix"])
     subprocess.check_call(["jupyter", "serverextension", "disable", "beakerx_tabledisplay", "--py", "--sys-prefix"])
-    if LAB_VERSION is not None:
+    if LAB_VERSION is not None and LAB_VERSION < 3:
         subprocess.call(["jupyter", "labextension", "uninstall", "beakerx-jupyterlab"],
                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 


### PR DESCRIPTION
We do not need to install the labextension manually for JupyterLab 3 AND 4. This PR adds support for install the widget in JupyterLab 4.