### PR TITLE
Release 2.4.0

### DIFF
--- a/beakerx_tabledisplay/beakerx_tabledisplay/_version.py
+++ b/beakerx_tabledisplay/beakerx_tabledisplay/_version.py
@@ -1,2 +1,2 @@
-version_info = (2, 3, 13)
+version_info = (2, 4, 0)
 __version__ = '.'.join(map(str, version_info))

--- a/beakerx_tabledisplay/js/package.json
+++ b/beakerx_tabledisplay/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beakerx/beakerx-tabledisplay",
-  "version": "2.3.13",
+  "version": "2.4.0",
   "description": "BeakerX: Beaker TableDisplay Extension for Jupyter Notebook and Lab",
   "homepage": "http://beakerx.com/",
   "keywords": [

--- a/beakerx_tabledisplay/setup.py
+++ b/beakerx_tabledisplay/setup.py
@@ -71,7 +71,7 @@ setup_args = dict(
     license_file="LICENSE",
     long_description=pkg_json["description"],
     packages=setuptools.find_packages(),
-    install_requires=["beakerx_base>=2.2.0", "numpy", "pandas"],
+    install_requires=["beakerx_base>=2.3,<3", "numpy", "pandas"],
     zip_safe=False,
     include_package_data=True,
     python_requires=">=3",

--- a/beakerx_tabledisplay/setup.py
+++ b/beakerx_tabledisplay/setup.py
@@ -71,7 +71,7 @@ setup_args = dict(
     license_file="LICENSE",
     long_description=pkg_json["description"],
     packages=setuptools.find_packages(),
-    install_requires=["beakerx_base>=2.0.1", "numpy", "pandas"],
+    install_requires=["beakerx_base>=2.2.0", "numpy", "pandas"],
     zip_safe=False,
     include_package_data=True,
     python_requires=">=3",


### PR DESCRIPTION
This PR is blocked by:
- Bug fix on the labextension install: https://github.com/twosigma/beakerx_tabledisplay/pull/97
- beakerx_base release https://github.com/twosigma/beakerx_base/pull/11